### PR TITLE
simple fix for grid_size in yolov4_head when using custom img_size

### DIFF
--- a/custom_layers.py
+++ b/custom_layers.py
@@ -1,5 +1,6 @@
 import tensorflow as tf
 from tensorflow.keras import layers, initializers, models
+from config import yolo_config
 
 
 def conv(x, filters, kernel_size, downsampling=False, activation='leaky', batch_norm=True):
@@ -199,17 +200,18 @@ def yolov4_neck(x, num_classes):
 
 
 def yolov4_head(yolo_neck_outputs, classes, anchors, xyscale):
+    size = yolo_config['img_size'][0]
     bbox0, object_probability0, class_probabilities0, pred_box0 = get_boxes(yolo_neck_outputs[0],
                                                                             anchors=anchors[0, :, :], classes=classes,
-                                                                            grid_size=52, strides=8,
+                                                                            grid_size=int(52*(size/416)), strides=8,
                                                                             xyscale=xyscale[0])
     bbox1, object_probability1, class_probabilities1, pred_box1 = get_boxes(yolo_neck_outputs[1],
                                                                             anchors=anchors[1, :, :], classes=classes,
-                                                                            grid_size=26, strides=16,
+                                                                            grid_size=int(26*(size/416)), strides=16,
                                                                             xyscale=xyscale[1])
     bbox2, object_probability2, class_probabilities2, pred_box2 = get_boxes(yolo_neck_outputs[2],
                                                                             anchors=anchors[2, :, :], classes=classes,
-                                                                            grid_size=13, strides=32,
+                                                                            grid_size=int(13*(size/416)), strides=32,
                                                                             xyscale=xyscale[2])
     x = [bbox0, object_probability0, class_probabilities0, pred_box0,
          bbox1, object_probability1, class_probabilities1, pred_box1,


### PR DESCRIPTION
There was an error when calling `model.predict` when using custom _img_size_ other than **416x416**:

```
Invalid argument:  Input to reshape is a tensor with _XX_ values, but the requested shape has _YY_
         [[node functional_9/tf_op_layer_Reshape_12/Reshape_12 (defined at ./yolo\models.py:115) ]]
         [[functional_9/tf_op_layer_Mul_89/Mul_89/_6]]
```

This is caused by the incompatibility of _grid_size_ when calling `get_boxes` inside of `yolov4_head`. This is a simple fix I use in my fork, which scales the _grid_size_ accordingly to the custom _img_size_. Merge if you find it suitable.

BTW @taipingeric thank you for your work! 